### PR TITLE
Refactoring - 1.1.0

### DIFF
--- a/.autotest
+++ b/.autotest
@@ -3,24 +3,6 @@
 require "autotest/restart"
 
 Autotest.add_hook :initialize do |at|
-  at.testlib = "minitest/autorun"
+  at.testlib = ".minitest"
   at.add_exception "tmp"
-
-#   at.extra_files << "../some/external/dependency.rb"
-#
-#   at.libs << ":../some/external"
-#
-#   at.add_exception "vendor"
-#
-#   at.add_mapping(/dependency.rb/) do |f, _|
-#     at.files_matching(/test_.*rb$/)
-#   end
-#
-#   %w(TestA TestB).each do |klass|
-#     at.extra_class_map[klass] = "test/test_misc.rb"
-#   end
 end
-
-# Autotest.add_hook :run_command do |at|
-#   system "rake build"
-# end

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-pkg
+pkg/
+doc/
 .*.sw*

--- a/.minitest.rb
+++ b/.minitest.rb
@@ -1,0 +1,2 @@
+gem "minitest"
+require "minitest/autorun"

--- a/README.txt
+++ b/README.txt
@@ -16,20 +16,6 @@ Expactations are then builded using these methods.
 * Enables you to use existing matcher classes from projects like
   valid_attribute, (with some additional work) shoulda-matchers and remarkable.
 
-* when using MiniTest::Matchers#must we run the matcher in the context
-  of spec class, not spec instance, so you can't use spec instance level
-  methods/variables just yet:
-
-    describe "index" do
-      let(:post) { Factory.create(:post) }
-      before { get :show, :id => post.to_param }
-
-      must { respond_with(:success) }      # works
-      must { assign_to(:post).with(post) } # won't work
-    end
-
-  We don't support these things in the matcher description for the same reasons.
-
 == SYNOPSIS:
 
 * see example matcher: https://github.com/bcardarella/valid_attribute/blob/master/lib/valid_attribute/matcher.rb
@@ -77,13 +63,13 @@ Expactations are then builded using these methods.
     describe Post do
       subject { Post.new }
 
-      must { have_valid(:title).when("Hello") }
-      wont { have_valid(:title).when("", nil, "Bad") }
+      it { must have_valid(:title).when("Hello") }
+      it { wont have_valid(:title).when("", nil, "Bad") }
     end
 
 == REQUIREMENTS:
 
-* minitest >= 2.5.0
+* minitest >= 2.7.0
 
 == INSTALL:
 

--- a/lib/minitest/matchers.rb
+++ b/lib/minitest/matchers.rb
@@ -3,6 +3,23 @@ require "minitest/spec"
 module MiniTest::Matchers
   VERSION = "1.1.0" # :nodoc:
 
+  ##
+  # Every matcher must respond to following methods:
+  #   - #description
+  #   - #matches?
+  #   - #failure_message
+  #   - #negative_failure_message
+
+  def self.check_matcher matcher
+    [:description, :matches?, :failure_message, :negative_failure_message].each do |m|
+      unless matcher.respond_to? m
+        fail "Matcher must respond to #{m}."
+      end
+    end
+  end
+end
+
+module MiniTest
   module Assertions
     ##
     # Fails unless matcher.matches?(subject) returns true
@@ -31,8 +48,7 @@ module MiniTest::Matchers
 
   module Expectations
     ##
-    # See MiniTest::Matchers::Assertions#assert_must
-    #
+    # See MiniTest::Assertions#assert_must
     #     user.must have_valid(:email).when("user@example.com")
     #
     # :method: must
@@ -40,7 +56,7 @@ module MiniTest::Matchers
     infect_an_assertion :assert_must, :must
 
     ##
-    # See MiniTest::Matchers::Assertions#assert_wont
+    # See MiniTest::Assertions#assert_wont
     #
     #     user.wont have_valid(:email).when("bad@email")
     #
@@ -48,55 +64,6 @@ module MiniTest::Matchers
 
     infect_an_assertion :assert_wont, :wont
   end
-
-  def must &block
-    matcher = yield
-    MiniTest::Matchers.check_matcher matcher
-
-    it "must #{matcher.description}" do
-      fail "Please set subject" unless self.respond_to? :subject
-
-      assert_must matcher, subject
-    end
-
-    matcher
-  end
-
-  def wont &block
-    matcher = yield
-    MiniTest::Matchers.check_matcher matcher
-
-    it "wont #{matcher.description}" do
-      fail "Please set subject" unless self.respond_to? :subject
-
-      assert_wont matcher, subject
-    end
-
-    matcher
-  end
-
-  ##
-  # Every matcher must respond to following methods:
-  #   - #description
-  #   - #matches?
-  #   - #failure_message
-  #   - #negative_failure_message
-
-  def self.check_matcher matcher
-    [:description, :matches?, :failure_message, :negative_failure_message].each do |m|
-      unless matcher.respond_to? m
-        fail "Matcher must respond to #{m}."
-      end
-    end
-  end
-end
-
-module MiniTest::Assertions # :nodoc:
-  include MiniTest::Matchers::Assertions
-end
-
-module MiniTest::Expectations # :nodoc:
-  include MiniTest::Matchers::Expectations
 end
 
 class MiniTest::Spec # :nodoc:

--- a/lib/minitest/matchers.rb
+++ b/lib/minitest/matchers.rb
@@ -1,7 +1,7 @@
 require "minitest/spec"
 
 module MiniTest::Matchers
-  VERSION = "1.1.0" # :nodoc:
+  VERSION = "1.1.0.rc2" # :nodoc:
 
   ##
   # Every matcher must respond to following methods:

--- a/lib/minitest/matchers.rb
+++ b/lib/minitest/matchers.rb
@@ -5,6 +5,7 @@ module MiniTest::Matchers
 
   ##
   # Every matcher must respond to following methods:
+  #
   #   - #description
   #   - #matches?
   #   - #failure_message
@@ -23,6 +24,12 @@ module MiniTest
   module Assertions
     ##
     # Fails unless matcher.matches?(subject) returns true
+    #
+    # Example:
+    #
+    #   def test_validations
+    #     assert_must be_valid, @user
+    #   end
 
     def assert_must matcher, subject, msg = nil
       MiniTest::Matchers.check_matcher matcher
@@ -35,6 +42,12 @@ module MiniTest
 
     ##
     # Fails if matcher.matches?(subject) returns true
+    #
+    # Example:
+    #
+    #   def test_validations
+    #     assert_wont be_valid, @user
+    #   end
 
     def assert_wont matcher, subject, msg = nil
       MiniTest::Matchers.check_matcher matcher
@@ -49,6 +62,7 @@ module MiniTest
   module Expectations
     ##
     # See MiniTest::Assertions#assert_must
+    #
     #     user.must have_valid(:email).when("user@example.com")
     #
     # :method: must

--- a/lib/minitest/matchers.rb
+++ b/lib/minitest/matchers.rb
@@ -5,7 +5,6 @@ module MiniTest::Matchers
 
   ##
   # Every matcher must respond to following methods:
-  #
   #   - #description
   #   - #matches?
   #   - #failure_message
@@ -80,6 +79,46 @@ module MiniTest
   end
 end
 
+class MiniTest::Spec
+  ##
+  # Define a `must` expectation for implicit subject
+  #
+  # Example:
+  #
+  #   describe Post do
+  #     subject { Post.new }
+  #
+  #     it { must have_valid(:title).when("Good") }
+  #   end
+
+  def must(*args, &block)
+    if respond_to?(:subject)
+      subject.must(*args, &block)
+    else
+      super
+    end
+  end
+
+  ##
+  # Define a `wont` expectation for implicit subject
+  #
+  # Example:
+  #
+  #   describe Post do
+  #     subject { Post.new }
+  #
+  #     it { wont have_valid(:title).when("") }
+  #   end
+
+  def wont(*args, &block)
+    if respond_to?(:subject)
+      subject.wont(*args, &block)
+    else
+      super
+    end
+  end
+end
+
 class MiniTest::Spec # :nodoc:
-  extend MiniTest::Matchers
+  include MiniTest::Matchers
 end

--- a/lib/minitest/matchers.rb
+++ b/lib/minitest/matchers.rb
@@ -1,40 +1,53 @@
 require "minitest/spec"
 
-module MiniTest::Assertions
-  def assert_must matcher, subject, msg = nil
-    MiniTest::Matchers.check_matcher matcher
-    result = matcher.matches? subject
-
-    msg ||= if matcher.respond_to? :failure_message
-              matcher.failure_message
-            else
-              "expected to " + matcher.description
-            end
-
-    assert result, msg
-  end
-
-  def assert_wont matcher, subject, msg = nil
-    MiniTest::Matchers.check_matcher matcher
-    result = matcher.matches? subject
-
-    msg ||= if matcher.respond_to? :negative_failure_message
-              matcher.negative_failure_message
-            else
-              "expected not to " + matcher.description
-            end
-
-    refute result, msg
-  end
-end
-
-module MiniTest::Expectations
-  infect_an_assertion :assert_must, :must
-  infect_an_assertion :assert_wont, :wont
-end
-
 module MiniTest::Matchers
-  VERSION = "1.1.0"
+  VERSION = "1.1.0" # :nodoc:
+
+  module Assertions
+    ##
+    # Fails unless matcher.matches?(subject) returns true
+
+    def assert_must matcher, subject, msg = nil
+      MiniTest::Matchers.check_matcher matcher
+      result = matcher.matches? subject
+
+      msg = message(msg) { matcher.failure_message }
+
+      assert result, msg
+    end
+
+    ##
+    # Fails if matcher.matches?(subject) returns true
+
+    def assert_wont matcher, subject, msg = nil
+      MiniTest::Matchers.check_matcher matcher
+      result = matcher.matches? subject
+
+      msg = message(msg) { matcher.negative_failure_message }
+
+      refute result, msg
+    end
+  end
+
+  module Expectations
+    ##
+    # See MiniTest::Matchers::Assertions#assert_must
+    #
+    #     user.must have_valid(:email).when("user@example.com")
+    #
+    # :method: must
+
+    infect_an_assertion :assert_must, :must
+
+    ##
+    # See MiniTest::Matchers::Assertions#assert_wont
+    #
+    #     user.wont have_valid(:email).when("bad@email")
+    #
+    # :method: wont
+
+    infect_an_assertion :assert_wont, :wont
+  end
 
   def must &block
     matcher = yield
@@ -62,15 +75,30 @@ module MiniTest::Matchers
     matcher
   end
 
+  ##
+  # Every matcher must respond to following methods:
+  #   - #description
+  #   - #matches?
+  #   - #failure_message
+  #   - #negative_failure_message
+
   def self.check_matcher matcher
-    [:description, :matches?].each do |m|
-      if !matcher.respond_to?(m) || matcher.send(:description).nil?
+    [:description, :matches?, :failure_message, :negative_failure_message].each do |m|
+      unless matcher.respond_to? m
         fail "Matcher must respond to #{m}."
       end
     end
   end
 end
 
-class MiniTest::Spec
+module MiniTest::Assertions # :nodoc:
+  include MiniTest::Matchers::Assertions
+end
+
+module MiniTest::Expectations # :nodoc:
+  include MiniTest::Matchers::Expectations
+end
+
+class MiniTest::Spec # :nodoc:
   extend MiniTest::Matchers
 end

--- a/test/test_minitest_matchers.rb
+++ b/test/test_minitest_matchers.rb
@@ -17,6 +17,14 @@ class KindOfMatcher
   def matches? subject
     subject.kind_of?  @klass
   end
+
+  def failure_message
+    "expected to " + description
+  end
+
+  def negative_failure_message
+    "expected not to " + description
+  end
 end
 
 def be_kind_of klass

--- a/test/test_minitest_matchers.rb
+++ b/test/test_minitest_matchers.rb
@@ -1,7 +1,7 @@
+gem "minitest"
+require "minitest/spec"
 require "minitest/autorun"
 require "minitest/matchers"
-
-class BadSpec < MiniTest::Spec; end
 
 class BadMatcher; end
 
@@ -48,6 +48,10 @@ describe MiniTest::Unit::TestCase do
 end
 
 describe MiniTest::Spec do
+  it "needs to verify matcher has #description and #matches?" do
+    proc { [].must BadMatcher.new, [] }.must_raise RuntimeError
+  end
+
   it "needs to verify must" do
     [].must(be_kind_of(Array)).must_equal true
     proc { [].must be_kind_of(String) }.must_raise MiniTest::Assertion
@@ -57,60 +61,32 @@ describe MiniTest::Spec do
     [].wont(be_kind_of(String)).must_equal false
     proc { [].wont be_kind_of(Array) }.must_raise MiniTest::Assertion
   end
-end
 
-describe MiniTest::Matchers do
-  describe "must" do
-    let(:spec_class) do
-      Class.new(MiniTest::Spec) do
-        must { KindOfMatcher.new String }
-      end
-    end
-    let(:spec) { spec_class.new "A spec" }
+  it "needs to verify must with implicit subject" do
+    spec_class = Class.new(MiniTest::Spec) do
+      subject { [1, 2, 3] }
 
-    it "defines must expectation" do
-      spec_class.test_methods.grep(/must_be_kind_of/).size.must_equal 1
+      it("1") { must be_kind_of(Array) }
+      it("2") { must be_kind_of(String) }
     end
 
-    it "rejects without subject" do
-      proc { spec.send(spec_class.test_methods.first) }.must_raise RuntimeError
-    end
+    spec = spec_class.new("A spec")
 
-    it "verifies match" do
-      spec_class.send(:subject) { "hello" }
-      spec.send(spec_class.test_methods.first).must_equal true
-    end
-
-    it "verifies mismatch" do
-      spec_class.send(:subject) { 1 }
-      proc { spec.send spec_class.test_methods.first }.must_raise MiniTest::Assertion
-    end
+    spec.send "test_0001_1"
+    proc { spec.send "test_0002_2"}.must_raise MiniTest::Assertion
   end
 
-  describe "wont" do
-    let(:spec_class) do
-      Class.new(MiniTest::Spec) do
-        wont { KindOfMatcher.new String }
-      end
-    end
-    let(:spec) { spec_class.new "A spec" }
+  it "needs to verify wont with implicit subject" do
+    spec_class = Class.new(MiniTest::Spec) do
+      subject { [1, 2, 3] }
 
-    it "defines wont expectation" do
-      spec_class.test_methods.grep(/wont_be_kind_of/).size.must_equal 1
+      it("1") { wont be_kind_of(String) }
+      it("2") { wont be_kind_of(Array) }
     end
 
-    it "rejects without subject" do
-      proc { spec.send(spec_class.test_methods.first) }.must_raise RuntimeError
-    end
+    spec = spec_class.new("A spec")
 
-    it "verifies match" do
-      spec_class.send(:subject) { "hello" }
-      proc { spec.send spec_class.test_methods.first }.must_raise MiniTest::Assertion
-    end
-
-    it "verifies mismatch" do
-      spec_class.send(:subject) { 1 }
-      spec.send(spec_class.test_methods.first).must_equal false
-    end
+    spec.send "test_0001_1"
+    proc { spec.send "test_0002_2"}.must_raise MiniTest::Assertion
   end
 end

--- a/test/test_minitest_matchers.rb
+++ b/test/test_minitest_matchers.rb
@@ -1,6 +1,8 @@
 require "minitest/autorun"
 require "minitest/matchers"
 
+class BadSpec < MiniTest::Spec; end
+
 class BadMatcher; end
 
 class KindOfMatcher
@@ -8,75 +10,99 @@ class KindOfMatcher
     @klass = klass
   end
 
-  def description; "be kind of #{@klass}" end
+  def description
+    "be kind of #{@klass}"
+  end
 
-  def matches? subject; subject.kind_of? @klass end
+  def matches? subject
+    subject.kind_of?  @klass
+  end
 end
 
-class BadSpec < MiniTest::Spec; end
-class GoodSpec < MiniTest::Spec
-  subject { [1, 2, 3] }
+def be_kind_of klass
+  KindOfMatcher.new klass
+end
+
+describe MiniTest::Unit::TestCase do
+  it "needs to verify matcher has #description and #matches?" do
+    proc { assert_must BadMatcher.new, [] }.must_raise RuntimeError
+  end
+
+  it "needs to verify assert_must" do
+    assert_must(be_kind_of(Array), []).must_equal true
+    proc { assert_must be_kind_of(String), [] }.must_raise MiniTest::Assertion
+  end
+
+  it "needs to verify assert_wont" do
+    assert_wont(be_kind_of(String), []).must_equal false
+    proc { assert_wont be_kind_of(Array), [] }.must_raise MiniTest::Assertion
+  end
+end
+
+describe MiniTest::Spec do
+  it "needs to verify must" do
+    [].must(be_kind_of(Array)).must_equal true
+    proc { [].must be_kind_of(String) }.must_raise MiniTest::Assertion
+  end
+
+  it "needs to verify wont" do
+    [].wont(be_kind_of(String)).must_equal false
+    proc { [].wont be_kind_of(Array) }.must_raise MiniTest::Assertion
+  end
 end
 
 describe MiniTest::Matchers do
-  let(:bad_spec)  { Class.new(BadSpec) }
-  let(:good_spec) { Class.new(GoodSpec) }
-
-  describe "check_matcher" do
-    it "requires spec to have subject" do
-      proc { bad_spec.must { BadMatcher.new } }.must_raise RuntimeError
-    end
-
-    it "requires matcher to have #description and #matches?" do
-      proc { good_spec.must { BadMatcher.new } }.must_raise RuntimeError
-      good_spec.must { KindOfMatcher.new(Object) }.must_be_kind_of KindOfMatcher
-    end
-  end
-
   describe "must" do
-    subject do
-      Class.new(good_spec) do
+    let(:spec_class) do
+      Class.new(MiniTest::Spec) do
         must { KindOfMatcher.new String }
       end
     end
-
-    let(:spec) { subject.new "A spec" }
+    let(:spec) { spec_class.new "A spec" }
 
     it "defines must expectation" do
-      subject.test_methods.grep(/must_be_kind_of/).size.must_equal 1
+      spec_class.test_methods.grep(/must_be_kind_of/).size.must_equal 1
     end
 
-    it "passes when matches" do
-      subject.send(:subject) { "hello" }
-      proc { spec.send subject.test_methods.first }
+    it "rejects without subject" do
+      proc { spec.send(spec_class.test_methods.first) }.must_raise RuntimeError
     end
 
-    it "raises error when does not match" do
-      subject.send(:subject) { 1 }
-      proc { spec.send subject.test_methods.first }.must_raise MiniTest::Assertion
+    it "verifies match" do
+      spec_class.send(:subject) { "hello" }
+      spec.send(spec_class.test_methods.first).must_equal true
+    end
+
+    it "verifies mismatch" do
+      spec_class.send(:subject) { 1 }
+      proc { spec.send spec_class.test_methods.first }.must_raise MiniTest::Assertion
     end
   end
 
   describe "wont" do
-    subject do
-      Class.new(good_spec) do
+    let(:spec_class) do
+      Class.new(MiniTest::Spec) do
         wont { KindOfMatcher.new String }
       end
     end
-    let(:spec) { subject.new "A spec" }
+    let(:spec) { spec_class.new "A spec" }
 
     it "defines wont expectation" do
-      subject.test_methods.grep(/wont_be_kind_of/).size.must_equal 1
+      spec_class.test_methods.grep(/wont_be_kind_of/).size.must_equal 1
     end
 
-    it "passes when does not match" do
-      subject.send(:subject) { 1 }
-      proc { spec.send subject.test_methods.first }
+    it "rejects without subject" do
+      proc { spec.send(spec_class.test_methods.first) }.must_raise RuntimeError
     end
 
-    it "raises error when matches" do
-      subject.send(:subject) { "hello" }
-      proc { spec.send subject.test_methods.first }.must_raise MiniTest::Assertion
+    it "verifies match" do
+      spec_class.send(:subject) { "hello" }
+      proc { spec.send spec_class.test_methods.first }.must_raise MiniTest::Assertion
+    end
+
+    it "verifies mismatch" do
+      spec_class.send(:subject) { 1 }
+      spec.send(spec_class.test_methods.first).must_equal false
     end
   end
 end


### PR DESCRIPTION
Hi,

@zenspider, @bcardarella: since you are of few people who actually used this thing I'll love your feedback

I made some important changes:
- dropped class level `must`, `wont`. Instead use anonymous `it`.
- added implicit subject for `must`, `wont` in the spec
  Both README and rdocs are updated.

At the end of the day you can use it just like in RSpec (which is kinda cool thing to accomplish):

``` ruby
describe Post do
  it { must have_valid(:title).when("Good") }
end
```
